### PR TITLE
fix: remove duplicate using namespace declaration

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,8 +11,6 @@
 #include "sensesp_app_builder.h"
 #include "sensesp_onewire/onewire_temperature.h"
 
-using namespace sensesp::onewire;
-
 // 1-Wire data pin on SH-ESP32
 #define ONEWIRE_PIN 4
 


### PR DESCRIPTION
## Summary
- Removes duplicate `using namespace sensesp::onewire;` declaration that was accidentally introduced in PR #6

## Test plan
- [ ] Verify build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)